### PR TITLE
fix: fix typo in a code block comment

### DIFF
--- a/docs/cs/tools/mkdocs.md
+++ b/docs/cs/tools/mkdocs.md
@@ -50,7 +50,7 @@ $ mkdocs gh-deploy
 - `theme: `  主题样式例如:
     ```yaml
     theme: 
-      name: 'material'     # 使用material主题,需要pip安   装mkdocs-material
+      name: 'material'     # 使用material主题,需要pip安装mkdocs-material
       language: 'zh'       # 使用中文
       icon:
         logo: ...          # 左上角的 logo 


### PR DESCRIPTION
移除了第53行的注释中“安装”两字间的三个空格，疑似笔误